### PR TITLE
Use `${{github.token}}` as default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'tag-exists-action: true'
+        id: checkTag
+        uses: ./
+        with: 
+          tag: 'v1.0.0'
+      - name: 'tag-exists-action: false'
+        id: notExist
+        uses: ./
+        with: 
+          tag: 'not-exist-tag-for-testing'
+
+      - name: Result of checkTag
+        run: test "true" = "${{ steps.checkTag.outputs.exists }}"
+      - name: Result of notExist
+        run: test "false" = "${{ steps.notExist.outputs.exists }}"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ A Github action that determines if a tag exists
 
 **Required** The tag to search for.
 
+### `github_token`
+
+GitHub token. default: `${{github.token}}`
+
 ## Outputs
 
 ### `exists`
@@ -20,8 +24,6 @@ a string value of 'true' or 'false'
   id: checkTag
   with: 
     tag: 'v1'
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 - run: echo ${{ steps.checkTag.outputs.exists }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   tag:  
     description: 'Tag to search for'
     required: true
+  github_token:
+    description: GitHub token
+    default: ${{ github.token }}
 outputs:
   exists: # id of output
     description: 'true or false'

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ async function run() {
         // Get owner and repo from context of payload that triggered the action
         const { owner, repo } = context.repo
 
-        const github = new GitHub(process.env.GITHUB_TOKEN);
+        const github = new GitHub(process.env.GITHUB_TOKEN || core.getInput('github_token'));
         var exists = 'false';
 
         try {


### PR DESCRIPTION
GitHub Actions can get a token via `github` context like `actions/checkout`. 
https://github.com/actions/checkout/blob/bf085276cecdb0cc76fbbe0687a5a0e786646936/action.yml

Users can get rid of `${{secrets.GITHUB_TOKENS}}`.

## Test result
https://github.com/kzrnm/tag-exists-action/actions/runs/3585985701