### PR TITLE
update outdated dependencies to avoid set-output warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/mukunku/tag-exists-action#readme",
   "dependencies": {
-    "@actions/core": "^1.9.1",
-    "@actions/github": "^2.1.1"
+    "@actions/core": "^1.10.0",
+    "@actions/github": "^5.1.1"
   }
 }


### PR DESCRIPTION
- Updated outdated dependency `@actions/core` to avoid the warning 
```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```