### PR TITLE
Add Support for Searching for Tags in other Repositories 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,13 @@ jobs:
       - name: Result of checkTag
         run: test "true" = "${{ steps.checkTag.outputs.exists }}"
       - name: Result of notExist
-        run: test "false" = "${{ steps.notExist.outputs.exists }}"
+        run: test "false" = "${{ steps.notExist.outputs.notExist }}"
+      - name: Result of externalRepoTagExists
+        run: test "true" = "${{ steps.checkTag.outputs.externalRepoTagExists }}"
+      - name: Result of externalRepoTagNotExists
+        run: test "true" = "${{ steps.checkTag.outputs.externalRepoTagNotExists }}"
+      - name: Result of externalRepoNotExists
+        run: test "true" = "${{ steps.checkTag.outputs.externalRepoNotExists }}"
 
   test-windows:
     name: Test Windows
@@ -83,7 +89,13 @@ jobs:
       - name: Result of checkTag
         run: test "true" = "${{ steps.checkTag.outputs.exists }}"
       - name: Result of notExist
-        run: test "false" = "${{ steps.notExist.outputs.exists }}"
+        run: test "false" = "${{ steps.notExist.outputs.notExist }}"
+      - name: Result of externalRepoTagExists
+        run: test "true" = "${{ steps.checkTag.outputs.externalRepoTagExists }}"
+      - name: Result of externalRepoTagNotExists
+        run: test "true" = "${{ steps.checkTag.outputs.externalRepoTagNotExists }}"
+      - name: Result of externalRepoNotExists
+        run: test "true" = "${{ steps.checkTag.outputs.externalRepoNotExists }}"
 
   test-macos:
     name: Test MacOS
@@ -122,4 +134,10 @@ jobs:
       - name: Result of checkTag
         run: test "true" = "${{ steps.checkTag.outputs.exists }}"
       - name: Result of notExist
-        run: test "false" = "${{ steps.notExist.outputs.exists }}"
+        run: test "false" = "${{ steps.notExist.outputs.notExist }}"
+      - name: Result of externalRepoTagExists
+        run: test "true" = "${{ steps.checkTag.outputs.externalRepoTagExists }}"
+      - name: Result of externalRepoTagNotExists
+        run: test "true" = "${{ steps.checkTag.outputs.externalRepoTagNotExists }}"
+      - name: Result of externalRepoNotExists
+        run: test "true" = "${{ steps.checkTag.outputs.externalRepoNotExists }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,24 @@ jobs:
         uses: ./
         with: 
           tag: 'not-exist-tag-for-testing'
+      - name: 'tag-exists-action: external repo - true'
+        id: externalRepoTagExists
+        uses: ./
+        with: 
+          tag: 'v3.6.0'
+          repo: 'actions/checkout'
+      - name: 'tag-exists-action: external repo - false'
+        id: externalRepoTagNotExists
+        uses: ./
+        with: 
+          tag: 'not-exist-tag-for-testing'
+          repo: 'actions/checkout'
+      - name: 'tag-exists-action: external repo exists - false'
+        id: externalRepoNotExists
+        uses: ./
+        with: 
+          tag: 'not-exist-tag-for-testing'
+          repo: 'fakeRepo/fakerepo'
 
       - name: Result of checkTag
         run: test "true" = "${{ steps.checkTag.outputs.exists }}"
@@ -43,7 +61,25 @@ jobs:
         uses: ./
         with: 
           tag: 'not-exist-tag-for-testing'
-
+      - name: 'tag-exists-action: external repo - true'
+        id: externalRepoTagExists
+        uses: ./
+        with: 
+          tag: 'v3.6.0'
+          repo: 'actions/checkout'
+      - name: 'tag-exists-action: external repo - false'
+        id: externalRepoTagNotExists
+        uses: ./
+        with: 
+          tag: 'not-exist-tag-for-testing'
+          repo: 'actions/checkout'
+      - name: 'tag-exists-action: external repo exists - false'
+        id: externalRepoNotExists
+        uses: ./
+        with: 
+          tag: 'not-exist-tag-for-testing'
+          repo: 'fakeRepo/fakerepo'
+          
       - name: Result of checkTag
         run: test "true" = "${{ steps.checkTag.outputs.exists }}"
       - name: Result of notExist
@@ -64,6 +100,24 @@ jobs:
         uses: ./
         with: 
           tag: 'not-exist-tag-for-testing'
+      - name: 'tag-exists-action: external repo - true'
+        id: externalRepoTagExists
+        uses: ./
+        with: 
+          tag: 'v3.6.0'
+          repo: 'actions/checkout'
+      - name: 'tag-exists-action: external repo - false'
+        id: externalRepoTagNotExists
+        uses: ./
+        with: 
+          tag: 'not-exist-tag-for-testing'
+          repo: 'actions/checkout'
+      - name: 'tag-exists-action: external repo exists - false'
+        id: externalRepoNotExists
+        uses: ./
+        with: 
+          tag: 'not-exist-tag-for-testing'
+          repo: 'fakeRepo/fakerepo'
 
       - name: Result of checkTag
         run: test "true" = "${{ steps.checkTag.outputs.exists }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,10 +53,10 @@ jobs:
         run: test "false" = "${{ steps.notExist.outputs.exists }}"
       - name: Result of externalRepoTagExists
         if: always()
-        run: test "true" = "${{ steps.checkTag.externalRepoTagExists.exists }}"
+        run: test "true" = "${{ steps.externalRepoTagExists.outputs.exists }}"
       - name: Result of externalRepoTagNotExists
         if: always()
-        run: test "true" = "${{ steps.externalRepoTagNotExists.outputs.exists }}"
+        run: test "false" = "${{ steps.externalRepoTagNotExists.outputs.exists }}"
       - name: Result of externalRepoNotExists
         if: always()
-        run: test "true" = "${{ steps.externalRepoNotExists.outputs.exists }}"
+        run: test "false" = "${{ steps.externalRepoNotExists.outputs.exists }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,12 @@ on:
       - master
 
 jobs:
-  test-unix:
+  test:
     name: Test Unix
-    runs-on: ubuntu-latest
+    strategy: 
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: 'tag-exists-action: true'
@@ -42,102 +45,17 @@ jobs:
           repo: 'fakeRepo/fakerepo'
 
       - name: Result of checkTag
+        if: always()
         run: test "true" = "${{ steps.checkTag.outputs.exists }}"
       - name: Result of notExist
+        if: always()
         run: test "false" = "${{ steps.notExist.outputs.notExist }}"
       - name: Result of externalRepoTagExists
+        if: always()
         run: test "true" = "${{ steps.checkTag.outputs.externalRepoTagExists }}"
       - name: Result of externalRepoTagNotExists
+        if: always()
         run: test "true" = "${{ steps.checkTag.outputs.externalRepoTagNotExists }}"
       - name: Result of externalRepoNotExists
-        run: test "true" = "${{ steps.checkTag.outputs.externalRepoNotExists }}"
-
-  test-windows:
-    name: Test Windows
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: 'tag-exists-action: true'
-        id: checkTag
-        uses: ./
-        with: 
-          tag: 'v1.0.0'
-      - name: 'tag-exists-action: false'
-        id: notExist
-        uses: ./
-        with: 
-          tag: 'not-exist-tag-for-testing'
-      - name: 'tag-exists-action: external repo - true'
-        id: externalRepoTagExists
-        uses: ./
-        with: 
-          tag: 'v3.6.0'
-          repo: 'actions/checkout'
-      - name: 'tag-exists-action: external repo - false'
-        id: externalRepoTagNotExists
-        uses: ./
-        with: 
-          tag: 'not-exist-tag-for-testing'
-          repo: 'actions/checkout'
-      - name: 'tag-exists-action: external repo exists - false'
-        id: externalRepoNotExists
-        uses: ./
-        with: 
-          tag: 'not-exist-tag-for-testing'
-          repo: 'fakeRepo/fakerepo'
-          
-      - name: Result of checkTag
-        run: test "true" = "${{ steps.checkTag.outputs.exists }}"
-      - name: Result of notExist
-        run: test "false" = "${{ steps.notExist.outputs.notExist }}"
-      - name: Result of externalRepoTagExists
-        run: test "true" = "${{ steps.checkTag.outputs.externalRepoTagExists }}"
-      - name: Result of externalRepoTagNotExists
-        run: test "true" = "${{ steps.checkTag.outputs.externalRepoTagNotExists }}"
-      - name: Result of externalRepoNotExists
-        run: test "true" = "${{ steps.checkTag.outputs.externalRepoNotExists }}"
-
-  test-macos:
-    name: Test MacOS
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: 'tag-exists-action: true'
-        id: checkTag
-        uses: ./
-        with: 
-          tag: 'v1.0.0'
-      - name: 'tag-exists-action: false'
-        id: notExist
-        uses: ./
-        with: 
-          tag: 'not-exist-tag-for-testing'
-      - name: 'tag-exists-action: external repo - true'
-        id: externalRepoTagExists
-        uses: ./
-        with: 
-          tag: 'v3.6.0'
-          repo: 'actions/checkout'
-      - name: 'tag-exists-action: external repo - false'
-        id: externalRepoTagNotExists
-        uses: ./
-        with: 
-          tag: 'not-exist-tag-for-testing'
-          repo: 'actions/checkout'
-      - name: 'tag-exists-action: external repo exists - false'
-        id: externalRepoNotExists
-        uses: ./
-        with: 
-          tag: 'not-exist-tag-for-testing'
-          repo: 'fakeRepo/fakerepo'
-
-      - name: Result of checkTag
-        run: test "true" = "${{ steps.checkTag.outputs.exists }}"
-      - name: Result of notExist
-        run: test "false" = "${{ steps.notExist.outputs.notExist }}"
-      - name: Result of externalRepoTagExists
-        run: test "true" = "${{ steps.checkTag.outputs.externalRepoTagExists }}"
-      - name: Result of externalRepoTagNotExists
-        run: test "true" = "${{ steps.checkTag.outputs.externalRepoTagNotExists }}"
-      - name: Result of externalRepoNotExists
+        if: always()
         run: test "true" = "${{ steps.checkTag.outputs.externalRepoNotExists }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,9 @@ on:
 
 jobs:
   test:
-    name: Test Unix
+    name: Run Operating System Tests 
     strategy: 
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
@@ -49,13 +50,13 @@ jobs:
         run: test "true" = "${{ steps.checkTag.outputs.exists }}"
       - name: Result of notExist
         if: always()
-        run: test "false" = "${{ steps.notExist.outputs.notExist }}"
+        run: test "false" = "${{ steps.notExist.outputs.exists }}"
       - name: Result of externalRepoTagExists
         if: always()
-        run: test "true" = "${{ steps.checkTag.outputs.externalRepoTagExists }}"
+        run: test "true" = "${{ steps.checkTag.externalRepoTagExists.exists }}"
       - name: Result of externalRepoTagNotExists
         if: always()
-        run: test "true" = "${{ steps.checkTag.outputs.externalRepoTagNotExists }}"
+        run: test "true" = "${{ steps.externalRepoTagNotExists.outputs.exists }}"
       - name: Result of externalRepoNotExists
         if: always()
-        run: test "true" = "${{ steps.checkTag.outputs.externalRepoNotExists }}"
+        run: test "true" = "${{ steps.externalRepoNotExists.outputs.exists }}"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ a string value of 'true' or 'false'
   id: checkTag
   with: 
     tag: 'tag-to-search-for'
+    repo: 'owner/repo-name'
 
 - run: echo ${{ steps.checkTag.outputs.exists }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   tag:  
     description: 'Tag to search for'
     required: true
+  repo:  
+    description: 'Repo to search for given tag'
+    default: ${{ github.repository }}
   github_token:
     description: GitHub token
     default: ${{ github.token }}

--- a/index.js
+++ b/index.js
@@ -4,14 +4,14 @@ const github = require('@actions/github');
 async function run() {
     try {
         //Get input
-        const tag = process.env.TAG || process.env.INPUT_TAG || ''
-        const repoInput = core.getInput('repo') || process.env.GITHUB_REPOSITORY 
+        const tag = process.env.TAG || process.env.INPUT_TAG || '';
+        const repoInput = core.getInput('repo') || process.env.GITHUB_REPOSITORY;
 
         console.log(`Searching for tag: ${tag} in ${repoInput}`);
 
         // Get owner and repo from context of payload that triggered the action
-        const [ owner, ...repository ] = repoInput.split('/')
-        const repo = repository.join('/')
+        const [ owner, ...repository ] = repoInput.split('/');
+        const repo = repository.join('/');
         
         const octokit = github.getOctokit(process.env.GITHUB_TOKEN || core.getInput('github_token'));
         var exists = 'false';

--- a/index.js
+++ b/index.js
@@ -5,10 +5,13 @@ async function run() {
     try {
         //Get input
         const tag = process.env.TAG || process.env.INPUT_TAG || '';
-        console.log(`Searching for tag: ${tag}`);
+        const repoInput = core.getInput('repoInput')
+
+        console.log(`Searching for tag: ${tag} in ${repoInput}`);
 
         // Get owner and repo from context of payload that triggered the action
-        const { owner, repo } = github.context.repo
+        const [ owner, ...repository ] = repoInput.split('/')
+        const repo = repository.join('/')
         
         const octokit = github.getOctokit(process.env.GITHUB_TOKEN || core.getInput('github_token'));
         var exists = 'false';

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ async function run() {
     try {
         //Get input
         const tag = process.env.TAG || process.env.INPUT_TAG || '';
-        const repoInput = core.getInput('repoInput')
+        const repoInput = process.env.GITHUB_REPOSITORY || core.getInput('repoInput')
 
         console.log(`Searching for tag: ${tag} in ${repoInput}`);
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ async function run() {
     try {
         //Get input
         const tag = process.env.TAG || process.env.INPUT_TAG || ''
-        const repoInput = core.getInput('repoInput') || process.env.GITHUB_REPOSITORY 
+        const repoInput = core.getInput('repo') || process.env.GITHUB_REPOSITORY 
 
         console.log(`Searching for tag: ${tag} in ${repoInput}`);
 

--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ const github = require('@actions/github');
 async function run() {
     try {
         //Get input
-        const tag = process.env.TAG || process.env.INPUT_TAG || '';
-        const repoInput = process.env.GITHUB_REPOSITORY || core.getInput('repoInput')
+        const tag = process.env.TAG || process.env.INPUT_TAG || ''
+        const repoInput = core.getInput('repoInput') || process.env.GITHUB_REPOSITORY 
 
         console.log(`Searching for tag: ${tag} in ${repoInput}`);
 


### PR DESCRIPTION
Saw issue #18, had the same request. 

Figured I'd take a swing at it. Happy to make any changes. 

### Changes 
- Add repo input to action.yml with default value of context's repository
- Parse repo input into owner/repository consts 
- Concat repo name back into a string with support for repo names with a slash (if that's even a thing...) 
- Update Readme
- Move to matrix of operating systems for test.yml, so that we no longer need to update each case individually. 
- Add test cases for Windows, Mac, Linux 
    - Add case for external repo with tag
    - Add case for external repo without tag
    - Add case for when external repo does not exist 

    
### Test Results 
- Passing test runs: https://github.com/zachgoncalves/tag-exists-action/actions/runs/5982380140
     - Failure on checkTag due to lack of 1.0.0 release in my fork.  
   
### Notes
- This is assuming the given token in the github context has access to the repo in question. I didn't add any fancy exception handling, but depending on the response from the GH API, I'm sure that could be done. 
- It's my first time contributing to a public action, so I'm happy to follow any guidance. 

