### PR TITLE
Better error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,15 +30,22 @@ async function run() {
             if (getRefResponse.status === 200) {
                 console.log("Tag was found");
                 exists = 'true';
+            } else {
+                core.setFailed("Unknown status was returned: " + getRefResponse.status);
             }
 
         } catch(error) {
-            console.log("Tag was not found");
+            if (error.status === 404) {
+              console.log("Tag was not found");
+            } else {
+              core.setFailed("Unknown status was returned: " + error.status);
+              console.error(error);
+            }
         }
-
         core.setOutput('exists', exists);
     } catch (error) {
         core.setFailed(error.message);
+        console.error(error);
     }
 }
 


### PR DESCRIPTION
Currently the code automaticly assumes that when there is an error that means the tag does not exist, but this is not always true (it could also have been a network error for example). It also does not handle the case where the tag exists, but the API does not return status 200.

This pullrequest performs much stricter checking for the status codes, so that its garantueed that the action will always return the correct value, and will fail if something unexpected happens.