### PR TITLE
update to node 20 as node 16 actions are now deprecated 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ outputs:
   exists: # id of output
     description: 'true or false'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'
 branding:
   icon: 'bookmark'  


### PR DESCRIPTION
ref https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/